### PR TITLE
fix: correct typo and minor formatting

### DIFF
--- a/courses/sql/1_basics/sql-basics.md
+++ b/courses/sql/1_basics/sql-basics.md
@@ -1,4 +1,4 @@
-﻿# What's SQL and what’s used for?
+﻿# What's SQL and what's used for?
 
 
 
@@ -16,21 +16,21 @@ Despite being an ANSI and ISO standard, each RDBMS has its own extension, Oracle
 
 DDL It's used for create and modify the DB structure and its objects.
 
-Commands are CREATE, DROP, ALTER, TRUNCATE and RENAME.
+Commands are `CREATE`, `DROP`, `ALTER`, `TRUNCATE` and `RENAME`.
 
 ## Data Manipulation Language
 
-DML It's used inserting, updating and deleting data in a DB, so we have INSERT, UPDATE and DELETE.
+DML It's used inserting, updating and deleting data in a DB, so we have `INSERT`, `UPDATE` and `DELETE`.
 
 ## Data Control Language
 
 DCL It's used for access the stored data.
 
-Commands are GRANT and REVOKE
+Commands are `GRANT` and `REVOKE`
 
 ## Transaction Control Language
 
-TCL It's used for handling the transaction, its commands are COMMIT and ROLLBACK.
+TCL It's used for handling the transaction, its commands are `COMMIT` and `ROLLBACK`.
 
 # Credits & Let’s connect
 

--- a/courses/sql/2_command-types/2_dml.md
+++ b/courses/sql/2_command-types/2_dml.md
@@ -1,6 +1,6 @@
 ﻿# Data Manipulation Language
 
-It's used inserting, updating and deleting data in a DB, so we have INSERT, UPDATE and DELETE.
+It's used inserting, updating and deleting data in a DB, so we have `INSERT`, `UPDATE` and `DELETE`.
 
 Before digging into DML commands, let's introduce the most used statement :
 ```sql
@@ -16,18 +16,15 @@ SELECT * FROM <tableName> WHERE 1=1;
 SELECT * FROM <tableName> WHERE 1=1 ORDER BY <columnName>;
 ```
 
-SELECT - clause to extract data from table(s)
+`SELECT` - clause to extract data from table(s)
 
-&ast; - (star) indicates all columns from table(s), otherwise we must specify
-    column(s) we want to extract
+`*` (star) - indicates all columns from table(s), otherwise we must specify column(s) we want to extract
 
-FROM - clause to retrieve row(s) from the referenced table(s)
+`FROM` - clause to retrieve row(s) from the referenced table(s)
 
-WHERE - clause to filter record(s), it's optional and could have boolean
-    operators like AND, OR, IN, LIKE, NOT, etc
+`WHERE` - clause to filter record(s), it's optional and could have boolean operators like `AND`, `OR`, `IN`, `LIKE`, `NOT`, etc
 
-ORDER BY - clause to order column(s), it's optional
-
+`ORDER BY` - clause to order column(s), it's optional
 
 ## Insert
 
@@ -51,12 +48,11 @@ INSERT INTO <tableName> (<columns>) SELECT <columns> FROM <anotherTableName>;
 ### Insert Example
 
 ```sql
-INSERT INTO employee (ID, FIRST_NAME, LAST_NAME)
-VALUES (1,'Manuel','Gentile');
+INSERT INTO employee (ID, FIRST_NAME, LAST_NAME) VALUES (1,'Manuel','Gentile');
 ```
 
 ```sql
-INSERT INTO employee VALUES (2,'John,'Doe);
+INSERT INTO employee VALUES (2,'John','Doe');
 ```
 
 ```sql

--- a/courses/sql/2_command-types/3_dcl.md
+++ b/courses/sql/2_command-types/3_dcl.md
@@ -6,7 +6,7 @@ Commands are GRANT and REVOKE.
 
 ## Grant
 
-It’s used to provide access or privileges on the database objects
+It's used to provide access or privileges on the database objects
 to the users.
 
 ```sql
@@ -18,7 +18,7 @@ TO {<userName> | <roleName>};
 
 ## Revoke
 
-It’s used to revoke access or privileges on the database objects to
+It's used to revoke access or privileges on the database objects to
 the users.
 
 ```sql

--- a/courses/sql/2_command-types/4_tcl.md
+++ b/courses/sql/2_command-types/4_tcl.md
@@ -19,9 +19,9 @@ interact concurrently with a database.
 
 ## Commit
 
-It’s used for saving data permanently on database. 
+It's used for saving data permanently on database. 
 
-Once a transaction has been committed, it’s not possible to restore its previous state.
+Once a transaction has been committed, it's not possible to restore its previous state.
 
 <u>It only works on DML commands.</u>
 
@@ -31,7 +31,7 @@ COMMIT;
 
 ### Commit Example
 
-Let’s assume table employee is empty.
+Let's assume table employee is empty.
 
 We are going to insert a single row, then we persist data (commit)
 and close the session.
@@ -47,7 +47,7 @@ SELECT * FROM employee;
 ```
 
 ```sql
-INSERT INTO employee VALUES (1,’Manuel’, ‘Gentile’);
+INSERT INTO employee VALUES (1,'Manuel', ‘Gentile');
 ```
 
 ```sql
@@ -58,15 +58,15 @@ COMMIT;
 ```sql
 -- another user opens the session
 SELECT * FROM employee;
--- 1 record found (1,’Manuel’, ‘Gentile’)
+-- 1 record found (1,'Manuel', ‘Gentile')
 ```
 
 
 ## Rollback
 
-It’s used for reverting data not persisted on database by a transaction.
+It's used for reverting data not persisted on database by a transaction.
 
-Once a transaction has been rollbacked, it’s not possible to restore its previous state.
+Once a transaction has been rollbacked, it's not possible to restore its previous state.
 
 <u>It only works on DML commands.</u>
 
@@ -76,7 +76,7 @@ ROLLBACK;
 
 ### Rollback Example
 
-Let’s assume table employee is empty.
+Let's assume table employee is empty.
 
 We are going to insert a single row, then we rollback the transaction data and close the session.
 
@@ -91,7 +91,7 @@ SELECT * FROM employee;
 ```
 
 ```sql
-INSERT INTO employee VALUES (1,’Manuel’, ‘Gentile’);
+INSERT INTO employee VALUES (1,'Manuel', 'Gentile');
 ```
 
 ```sql


### PR DESCRIPTION
This pr contains:
- sql code [formatted](https://github.com/manugentile/manugentile.github.io/pull/19/files#r1527384638)
- replace `’` character with single quote `'` in order to let user copy and paste example and improve readability - [link github pages](https://manugentile.github.io/courses/sql/2_command-types/4_tcl.html#rollback-example)
![image](https://github.com/manugentile/manugentile.github.io/assets/135032973/48a54a31-68a4-4f32-94c0-7f191cb9eb0d)

- typo on line 21 (dml) - [link github pages](https://manugentile.github.io/courses/sql/2_command-types/2_dml.html)
![image](https://github.com/manugentile/manugentile.github.io/assets/135032973/5eb76531-26ce-4ef5-a4aa-7216d10af8b0)

